### PR TITLE
fix(migrations): make dotenv a direct dependency so data-source resol…

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,7 @@
     "class-validator": "0.14.3",
     "cloudinary": "2.10.0",
     "csv-parse": "5.6.0",
+    "dotenv": "17.4.2",
     "nodemailer": "8.0.2",
     "passport-jwt": "4.0.1",
     "pg": "8.18.0",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       csv-parse:
         specifier: 5.6.0
         version: 5.6.0
+      dotenv:
+        specifier: 17.4.2
+        version: 17.4.2
       nodemailer:
         specifier: 8.0.2
         version: 8.0.2
@@ -1703,6 +1706,10 @@ packages:
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -5270,6 +5277,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.2.3: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
…ves in prod

The Fly release_command failed with 'Cannot find module dotenv/config' — data-source.ts imported dotenv, but it was only a transitive dep (via @nestjs/config), unresolvable from app code after pnpm prune --prod. Promote dotenv to a direct dependency (no-op in prod where env comes from Fly secrets; loads .env in local dev).