### PR TITLE
polish(branches): unify motion + design-system alignment in Branch Hub

### DIFF
--- a/frontend/src/features/branch-comparison/components/BranchComparisonFilters.tsx
+++ b/frontend/src/features/branch-comparison/components/BranchComparisonFilters.tsx
@@ -65,7 +65,7 @@ export function BranchComparisonFilters({
             : "Auto-updated";
 
   return (
-    <Card className="p-4 mb-6">
+    <Card className="p-5 mb-6">
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
           <div className="min-w-0 flex-1">

--- a/frontend/src/features/branch-management/components/BranchRow.tsx
+++ b/frontend/src/features/branch-management/components/BranchRow.tsx
@@ -14,7 +14,7 @@ export function BranchRow({
     onDelete,
 }: BranchRowProps) {
     return (
-        <tr className="border-b border-border hover:bg-surface-2">
+        <tr className="border-b border-border transition-colors hover:bg-surface-2">
             <td className="px-6 py-4">
                 <span className="inline-flex items-center px-2 py-1 rounded-md text-[11px] font-mono font-semibold bg-surface-2 text-text-2 border border-border">
                     {branch.code}
@@ -48,7 +48,9 @@ export function BranchRow({
                     </span>
                 )}
             </td>
-            <td className="px-6 py-4 text-text-1">{branch.staffCount}</td>
+            <td className="px-6 py-4 text-text-1 tabular-nums">
+                {branch.staffCount}
+            </td>
             <td className="px-6 py-4">
                 {branch.isActive ? (
                     <span className="inline-flex items-center gap-1.5 text-text-1 text-[13px]">

--- a/frontend/src/features/branch-management/components/BranchTable.tsx
+++ b/frontend/src/features/branch-management/components/BranchTable.tsx
@@ -36,7 +36,7 @@ export function BranchTable({
                 ) : (
                     <table className="w-full text-left border-collapse">
                         <thead>
-                            <tr className="border-b border-border text-[11px] uppercase tracking-widest text-text-3">
+                            <tr className="border-b border-border bg-surface-2 text-[11px] uppercase tracking-widest text-text-3">
                                 {HEADERS.map((h) => (
                                     <th
                                         key={h}

--- a/frontend/src/features/branch-performance/components/BranchHeaderCard.tsx
+++ b/frontend/src/features/branch-performance/components/BranchHeaderCard.tsx
@@ -9,7 +9,7 @@ interface BranchHeaderCardProps {
 
 export function BranchHeaderCard({ branch, admin }: BranchHeaderCardProps) {
     return (
-        <Card className="p-6 mb-6">
+        <Card className="p-5 mb-6">
             <div className="flex items-start justify-between flex-wrap gap-4">
                 <div className="min-w-0">
                     <div className="flex items-center gap-3 flex-wrap mb-2">

--- a/frontend/src/features/branch-performance/components/BranchKpiStrip.tsx
+++ b/frontend/src/features/branch-performance/components/BranchKpiStrip.tsx
@@ -9,6 +9,12 @@ interface BranchKpiStripProps {
     dailySalesSpark: number[];
 }
 
+// Staggered entrance + subtle hover lift. `backwards` fill keeps each card
+// hidden through its delay; the global prefers-reduced-motion block neutralises
+// the animation + transform for users who opt out.
+const CARD_MOTION =
+    'animate-in fade-in slide-in-from-bottom-3 [animation-fill-mode:backwards] transition-transform duration-200 hover:-translate-y-0.5';
+
 export function BranchKpiStrip({
     today,
     week,
@@ -18,6 +24,7 @@ export function BranchKpiStrip({
     return (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
             <KpiCard
+                className={`${CARD_MOTION} [animation-delay:0ms]`}
                 label="Today's revenue"
                 value={formatCurrencyWhole(today.sales)}
                 delta={`${today.transactions} transactions`}
@@ -25,6 +32,7 @@ export function BranchKpiStrip({
                 sparkData={dailySalesSpark.slice(-7) || [1, 2]}
             />
             <KpiCard
+                className={`${CARD_MOTION} [animation-delay:70ms]`}
                 label="Avg transaction"
                 value={formatCurrencyWhole(today.avgTransaction)}
                 delta="Today"
@@ -32,6 +40,7 @@ export function BranchKpiStrip({
                 sparkData={[3, 4, 5, 4, 6, 5, 7]}
             />
             <KpiCard
+                className={`${CARD_MOTION} [animation-delay:140ms]`}
                 label="This week"
                 value={formatCurrencyWhole(week.sales)}
                 delta={`${week.transactions} transactions`}
@@ -39,6 +48,7 @@ export function BranchKpiStrip({
                 sparkData={dailySalesSpark || [1, 2]}
             />
             <KpiCard
+                className={`${CARD_MOTION} [animation-delay:210ms]`}
                 label="Low stock items"
                 value={String(inventory.lowStockItems)}
                 delta={`${inventory.outOfStock} out of stock`}

--- a/frontend/src/pages/admin/BranchComparisonPage.tsx
+++ b/frontend/src/pages/admin/BranchComparisonPage.tsx
@@ -77,7 +77,7 @@ export function BranchComparisonPage({
   }
 
   return (
-    <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+    <div>
       {!embedded && (
         <PageHeader
           eyebrow="Branches"

--- a/frontend/src/pages/branches/BranchHubPage.tsx
+++ b/frontend/src/pages/branches/BranchHubPage.tsx
@@ -12,18 +12,27 @@ export function BranchHubPage() {
     const isAdmin = user?.role === UserRole.ADMIN;
 
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+        <div>
             <BranchHubTabs active={tab} onChange={setTab} />
 
-            {tab === 'overview' && (
-                isAdmin ? (
-                    <BranchManagementPage embedded={false} />
-                ) : (
-                    <BranchPerformancePage />
-                )
-            )}
+            {/* Keyed so each tab switch plays exactly one entrance; the single
+                animate-in lives here, not in the child pages (avoids double /
+                replayed animation). */}
+            <div
+                key={tab}
+                className="animate-in fade-in slide-in-from-bottom-2 duration-300"
+            >
+                {tab === 'overview' &&
+                    (isAdmin ? (
+                        <BranchManagementPage embedded={false} />
+                    ) : (
+                        <BranchPerformancePage />
+                    ))}
 
-            {tab === 'compare' && <BranchComparisonPage embedded={false} />}
+                {tab === 'compare' && (
+                    <BranchComparisonPage embedded={false} />
+                )}
+            </div>
         </div>
     );
 }

--- a/frontend/src/pages/branches/BranchManagementPage.tsx
+++ b/frontend/src/pages/branches/BranchManagementPage.tsx
@@ -1,6 +1,8 @@
 import { useBranchManagementPage } from '@/features/branch-management/hooks/useBranchManagementPage';
 import { BranchTable } from '@/features/branch-management/components/BranchTable';
 import { BranchFormModal } from '@/features/branch-management/components/BranchFormModal';
+import PageHeader from '@/components/ui/PageHeader';
+import Button from '@/components/ui/Button';
 
 interface BranchManagementPageProps {
     embedded?: boolean;
@@ -11,32 +13,19 @@ export function BranchManagementPage({
 }: BranchManagementPageProps = {}) {
     const p = useBranchManagementPage();
 
+    const createButton = <Button onClick={p.openCreate}>+ Create branch</Button>;
+
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-4 duration-700">
-            <div
-                className={
-                    embedded
-                        ? 'flex justify-end mb-4'
-                        : 'flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8'
-                }
-            >
-                {!embedded && (
-                    <div>
-                        <h1 className="text-2xl font-bold text-text-1 tracking-tight">
-                            Branch Management
-                        </h1>
-                        <p className="text-sm text-text-2 mt-1">
-                            Create, edit, and manage all branches
-                        </p>
-                    </div>
-                )}
-                <button
-                    onClick={p.openCreate}
-                    className="h-9 px-4 rounded-lg bg-primary text-text-inv text-sm font-bold hover:bg-primary-hover transition-all self-start sm:self-auto"
-                >
-                    + Create Branch
-                </button>
-            </div>
+        <div>
+            {embedded ? (
+                <div className="flex justify-end mb-4">{createButton}</div>
+            ) : (
+                <PageHeader
+                    title="Branch Management"
+                    subtitle="Create, edit, and manage all branches"
+                    actions={createButton}
+                />
+            )}
 
             <BranchTable
                 branches={p.branches}

--- a/frontend/src/pages/branches/BranchPerformancePage.tsx
+++ b/frontend/src/pages/branches/BranchPerformancePage.tsx
@@ -59,7 +59,7 @@ export function BranchPerformancePage() {
     const dailySalesSpark = chartData.map((c) => c.sales);
 
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+        <div>
             <BranchHeaderCard branch={data.branch} admin={data.admin} />
             <BranchKpiStrip
                 today={data.today}
@@ -79,7 +79,7 @@ export function BranchPerformancePage() {
                 chartData={chartData}
             />
             <MonthKpisRow month={data.month} />
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
                 <TopProductsTable topProducts={data.topProducts} />
                 <RecentTransactionsTable
                     recentTransactions={data.recentTransactions}


### PR DESCRIPTION
- Centralize the entrance animation in BranchHubPage (keyed by tab) and drop the per-page animate-in wrappers, so each tab switch plays one clean transition instead of a double/replayed one.
- Branch Management: replace the raw <h1>+<button> header with PageHeader + Button; add a header background + tabular-nums to the branch table.
- Branch Performance: BranchHeaderCard p-6->p-5, consistent mb-6 section rhythm (+ md:grid-cols-2 on the last grid), staggered KPI entrance with a subtle hover lift (reduced-motion safe via the global block).
- Branch Compare: drop the duplicate wrapper animation; filters card p-4->p-5.