### PR TITLE
feat(legal): make returns explicit in the refund policy

### DIFF
--- a/frontend/src/features/legal/__tests__/legal-pages.test.tsx
+++ b/frontend/src/features/legal/__tests__/legal-pages.test.tsx
@@ -15,7 +15,7 @@ import { BusinessTermsPage } from '../pages/BusinessTermsPage'
 const PAGES = [
     { title: 'Terms & Conditions', Comp: TermsPage },
     { title: 'Privacy Policy', Comp: PrivacyPage },
-    { title: 'Refund & Cancellation Policy', Comp: RefundPage },
+    { title: 'Refund, Return & Cancellation Policy', Comp: RefundPage },
     { title: 'Delivery & Pickup Policy', Comp: DeliveryPage },
     { title: 'Contact Us', Comp: ContactPage },
     { title: 'Business & Legal Terms (Terms of Use)', Comp: BusinessTermsPage },

--- a/frontend/src/features/legal/config/legal-pages.ts
+++ b/frontend/src/features/legal/config/legal-pages.ts
@@ -34,8 +34,8 @@ export const LEGAL_PAGES: LegalPageMeta[] = [
     {
         key: 'refund',
         route: FRONTEND_ROUTES.LEGAL_REFUND,
-        label: 'Refund & Cancellation',
-        title: 'Refund & Cancellation Policy',
+        label: 'Refund & Returns',
+        title: 'Refund, Return & Cancellation Policy',
     },
     {
         key: 'delivery',

--- a/frontend/src/features/legal/pages/RefundPage.tsx
+++ b/frontend/src/features/legal/pages/RefundPage.tsx
@@ -8,9 +8,9 @@ const B = BUSINESS_INFO
 export function RefundPage() {
     return (
         <LegalPage
-            title="Refund & Cancellation Policy"
+            title="Refund, Return & Cancellation Policy"
             effectiveDate={LEGAL_EFFECTIVE_DATE}
-            intro={`We want you to be happy with every order from ${B.tradeName}. This policy explains when you can cancel an order and how refunds work.`}
+            intro={`We want you to be happy with every order from ${B.tradeName}. This policy explains when you can cancel an order, return items, and how refunds work.`}
         >
             <LegalSection heading="1. Cancelling an order">
                 <LegalList
@@ -22,8 +22,10 @@ export function RefundPage() {
                 />
             </LegalSection>
 
-            <LegalSection heading="2. When you're entitled to a refund">
-                <LegalP>You can request a refund or replacement if:</LegalP>
+            <LegalSection heading="2. Returns & refund eligibility">
+                <LegalP>
+                    You can return an item and request a refund or replacement if:
+                </LegalP>
                 <LegalList
                     items={[
                         'An item is damaged, spoiled, expired, or defective on arrival;',

--- a/frontend/src/features/legal/pages/TermsPage.tsx
+++ b/frontend/src/features/legal/pages/TermsPage.tsx
@@ -64,11 +64,11 @@ export function TermsPage() {
                 </LegalP>
             </LegalSection>
 
-            <LegalSection heading="6. Cancellations & refunds">
+            <LegalSection heading="6. Returns, cancellations & refunds">
                 <LegalP>
                     Cancellations, returns, and refunds are governed by our
-                    Refund &amp; Cancellation Policy. Perishable goods carry
-                    specific conditions described there.
+                    Refund, Return &amp; Cancellation Policy. Perishable goods
+                    carry specific conditions described there.
                 </LegalP>
             </LegalSection>
 


### PR DESCRIPTION
Rename the page to "Refund, Return & Cancellation Policy" (title + footer label "Refund & Returns"; /legal/refund URL unchanged) and surface "Return" in section headings + the Terms cross-reference, so a PayHere/bank reviewer scanning link labels sees returns are covered.